### PR TITLE
fix bootstrap lock

### DIFF
--- a/graphormer/data/wrapper.py
+++ b/graphormer/data/wrapper.py
@@ -3,6 +3,7 @@
 
 import torch
 import numpy as np
+import torch_geometric
 from ogb.graphproppred import PygGraphPropPredDataset
 from ogb.lsc.pcqm4mv2_pyg import PygPCQM4Mv2Dataset
 from functools import lru_cache


### PR DESCRIPTION
without this line, when we run "bash pcqv1.sh" or other scripts, the program will get stuck, and if we try to stop it with ^C
^CTraceback (most recent call last):
  File "/root/anaconda3/envs/graph/bin/fairseq-train", line 8, in <module>
    sys.exit(cli_main())
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/fairseq_cli/train.py", line 512, in cli_main
    parser = options.get_training_parser()
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/fairseq/options.py", line 38, in get_training_parser
    parser = get_parser("Trainer", default_task)
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/fairseq/options.py", line 234, in get_parser
    utils.import_user_module(usr_args)
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/fairseq/utils.py", line 497, in import_user_module
    import_tasks(tasks_path, f"{module_name}.tasks")
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/fairseq/tasks/__init__.py", line 117, in import_tasks
    importlib.import_module(namespace + "." + task_name)
  File "/root/anaconda3/envs/graph/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Graphormer/graphormer/tasks/is2re.py", line 23, in <module>
    from ..data.dataset import EpochShuffleDataset
  File "/Graphormer/graphormer/data/dataset.py", line 9, in <module>
    from .wrapper import MyPygGraphPropPredDataset
  File "/Graphormer/graphormer/data/wrapper.py", line 6, in <module>
    from ogb.graphproppred import PygGraphPropPredDataset
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/ogb/graphproppred/__init__.py", line 1, in <module>
    from .evaluate import Evaluator
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/ogb/graphproppred/evaluate.py", line 1, in <module>
    from sklearn.metrics import roc_auc_score, average_precision_score
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/sklearn/__init__.py", line 82, in <module>
    from .base import clone
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/sklearn/base.py", line 17, in <module>
    from .utils import _IS_32BIT
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/sklearn/utils/__init__.py", line 25, in <module>
    from . import _joblib
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/sklearn/utils/_joblib.py", line 7, in <module>
    import joblib
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/joblib/__init__.py", line 113, in <module>
    from .memory import Memory, MemorizedResult, register_store_backend
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/joblib/memory.py", line 32, in <module>
    from ._store_backends import StoreBackendBase, FileSystemStoreBackend
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/joblib/_store_backends.py", line 15, in <module>
    from .backports import concurrency_safe_rename
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/joblib/backports.py", line 7, in <module>
    from distutils.version import LooseVersion
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 982, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 925, in _find_spec
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/_distutils_hack/__init__.py", line 90, in find_spec
    return method()
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/_distutils_hack/__init__.py", line 101, in spec_for_distutils
    mod = importlib.import_module('setuptools._distutils')
  File "/root/anaconda3/envs/graph/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/setuptools/__init__.py", line 16, in <module>
    import setuptools.version
  File "/root/anaconda3/envs/graph/lib/python3.9/site-packages/setuptools/version.py", line 1, in <module>
    import pkg_resources
  File "<frozen importlib._bootstrap>", line 211, in _lock_unlock_module
  File "<frozen importlib._bootstrap>", line 107, in acquire
KeyboardInterrupt.
However, if we import torch_geometric before we import ogb, the program will run smoothly.