### PR TITLE
Bugfix: Stop Floyd-Warshall algorithm dropping node 0 from paths

### DIFF
--- a/graphormer/data/algos.pyx
+++ b/graphormer/data/algos.pyx
@@ -15,7 +15,7 @@ def floyd_warshall(adjacency_matrix):
     adj_mat_copy = adjacency_matrix.astype(long, order='C', casting='safe', copy=True)
     assert adj_mat_copy.flags['C_CONTIGUOUS']
     cdef numpy.ndarray[long, ndim=2, mode='c'] M = adj_mat_copy
-    cdef numpy.ndarray[long, ndim=2, mode='c'] path = numpy.zeros([n, n], dtype=numpy.int64)
+    cdef numpy.ndarray[long, ndim=2, mode='c'] path = -1 * numpy.ones([n, n], dtype=numpy.int64)
 
     cdef unsigned int i, j, k
     cdef long M_ij, M_ik, cost_ikkj
@@ -56,7 +56,7 @@ def floyd_warshall(adjacency_matrix):
 
 def get_all_edges(path, i, j):
     cdef unsigned int k = path[i][j]
-    if k == 0:
+    if k == -1:
         return []
     else:
         return get_all_edges(path, i, k) + [k] + get_all_edges(path, k, j)


### PR DESCRIPTION
The current Floyd-Warshall path-finding algorithm uses 0 as padding, but 0 is also a valid node index. This causes a bug where paths returned from `get_all_edges` will never contain node 0, and instead will be short.
E.g. a path that should go [3, 2, 0, 5, 6] will instead return a shorter path [3, 2, 5, 6], meaning that some of the edge features are fetched incorrectly.
