### PR TITLE
fix bug in shortest path

### DIFF
--- a/graphormer/data/algos.pyx
+++ b/graphormer/data/algos.pyx
@@ -55,7 +55,7 @@ def floyd_warshall(adjacency_matrix):
 
 
 def get_all_edges(path, i, j):
-    cdef unsigned int k = path[i][j]
+    cdef int k = path[i][j]
     if k == -1:
         return []
     else:


### PR DESCRIPTION
Change `unsigned int` to `int` for `k` in `get_all_edges` in `algos.pyx`. The bug was introduced in #119 which including `-1`'s in the `path` matrix.